### PR TITLE
Adding code signing

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,6 +5,7 @@ workflows:
     environment:
       groups:
         - shorebird
+      flutter: stable
       android_signing:
         - codemagic
     scripts:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,7 +5,8 @@ workflows:
     environment:
       groups:
         - shorebird
-      flutter: stable
+      android_signing:
+        - codemagic
     scripts:
       - name: 🐦 Setup Shorebird
         script: |


### PR DESCRIPTION
Thanks for this sample! my build was failing with the following error:

```
✗ Failed to build: Flutter assets will be downloaded from https://download.shorebird.dev. Make sure you trust this source!

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/builder/clone/android/app/build.gradle' line: 88

* What went wrong:
A problem occurred evaluating project ':app'.
> path may not be null or empty string. path='null'
```

I added code signing and this fixed it.